### PR TITLE
add option for configparser

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,12 @@ Note: The progressbar functionality will run correctly on JupyterLab v0.35.6 wit
 ```console
  jupyter labextension install @jupyter-widgets/jupyterlab-manager
 ```
+
+Login credentials can also be provided in a configuration file, `~/.eddrc`:
+```
+[edd.server.org]
+username: my_user_name
+password: my_password
+```
+
+


### PR DESCRIPTION
A quick change that also lets you supply your login information via a config file (`~/.eddrc`), instead of having to supply it each time. @tianar